### PR TITLE
Add configMap resource, Update and Patch method, increase Go version

### DIFF
--- a/Dockerfile.dep
+++ b/Dockerfile.dep
@@ -1,4 +1,4 @@
-FROM golang:1.8.3
+FROM golang:1.11.4
 
 RUN apt-get update && apt-get install -y netcat python-pip gdb vim
 RUN pip install jsonschema

--- a/pkg/reconcile/reconcile_test.go
+++ b/pkg/reconcile/reconcile_test.go
@@ -72,7 +72,7 @@ func compareSubresourceMaps(expected subresourceMap, actual subresourceMap) func
 
 func TestGroupSubresourcesByCustomResource(t *testing.T) {
 	controllerRef := true
-	typeMeta := metav1.TypeMeta{"example", "example"}
+	typeMeta := metav1.TypeMeta{Kind: "example", APIVersion: "example"}
 	tests := map[string]struct {
 		namespace       string
 		gvk             schema.GroupVersionKind
@@ -95,10 +95,10 @@ func TestGroupSubresourcesByCustomResource(t *testing.T) {
 			crList: fake.CustomResourceListImpl{
 				Items: []fake.CustomResourceImpl{
 					{
-						typeMeta,
-						metav1.ObjectMeta{Name: "crdkind31"},
-						states.Running,
-						states.Running,
+						TypeMeta:    typeMeta,
+						ObjectMeta:  metav1.ObjectMeta{Name: "crdkind31"},
+						SpecState:   states.Running,
+						StatusState: states.Running,
 					},
 				},
 			},
@@ -128,10 +128,10 @@ func TestGroupSubresourcesByCustomResource(t *testing.T) {
 			crList: fake.CustomResourceListImpl{
 				Items: []fake.CustomResourceImpl{
 					{
-						typeMeta,
-						metav1.ObjectMeta{Name: "crdkind11"},
-						states.Running,
-						states.Running,
+						TypeMeta:    typeMeta,
+						ObjectMeta:  metav1.ObjectMeta{Name: "crdkind11"},
+						SpecState:   states.Running,
+						StatusState: states.Running,
 					},
 				},
 			},
@@ -169,10 +169,10 @@ func TestGroupSubresourcesByCustomResource(t *testing.T) {
 			crList: fake.CustomResourceListImpl{
 				Items: []fake.CustomResourceImpl{
 					{
-						typeMeta,
-						metav1.ObjectMeta{Name: "crdkind11"},
-						states.Running,
-						states.Running,
+						TypeMeta:    typeMeta,
+						ObjectMeta:  metav1.ObjectMeta{Name: "crdkind11"},
+						SpecState:   states.Running,
+						StatusState: states.Running,
 					},
 				},
 			},
@@ -203,10 +203,10 @@ func TestGroupSubresourcesByCustomResource(t *testing.T) {
 			crList: fake.CustomResourceListImpl{
 				Items: []fake.CustomResourceImpl{
 					{
-						typeMeta,
-						metav1.ObjectMeta{Name: "crdkind11"},
-						states.Running,
-						states.Running,
+						TypeMeta:    typeMeta,
+						ObjectMeta:  metav1.ObjectMeta{Name: "crdkind11"},
+						SpecState:   states.Running,
+						StatusState: states.Running,
 					},
 				},
 			},
@@ -249,10 +249,10 @@ func TestGroupSubresourcesByCustomResource(t *testing.T) {
 			crList: fake.CustomResourceListImpl{
 				Items: []fake.CustomResourceImpl{
 					{
-						typeMeta,
-						metav1.ObjectMeta{Name: "crdkind12"},
-						states.Running,
-						states.Running,
+						TypeMeta:    typeMeta,
+						ObjectMeta:  metav1.ObjectMeta{Name: "crdkind12"},
+						SpecState:   states.Running,
+						StatusState: states.Running,
 					},
 				},
 			},

--- a/pkg/reconcile/reconcile_test.go
+++ b/pkg/reconcile/reconcile_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2018 Intel Corporation
+// Copyright (c) 2019 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/resource/cfg_map_client.go
+++ b/pkg/resource/cfg_map_client.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2018 Intel Corporation
+// Copyright (c) 2019 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/resource/client.go
+++ b/pkg/resource/client.go
@@ -35,7 +35,9 @@ type Client interface {
 	// Delete deletes the object.
 	Delete(namespace string, name string) error
 	// Update updates the object.
-	Update(namespace string, name string, data []byte) error
+	Update(namespace string, name string, templateValues interface{}) error
+	// Patch updates the object using JSON patch.
+	Patch(namespace string, name string, data []byte) error
 	// Get retrieves the object.
 	Get(namespace, name string) (runtime.Object, error)
 	// List lists objects based on group, version and kind.

--- a/pkg/resource/client.go
+++ b/pkg/resource/client.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2018 Intel Corporation
+// Copyright (c) 2019 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/resource/deployment_client.go
+++ b/pkg/resource/deployment_client.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2018 Intel Corporation
+// Copyright (c) 2019 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/resource/fake/types.go
+++ b/pkg/resource/fake/types.go
@@ -73,7 +73,7 @@ func (c *SubresourceClient) Delete(namespace, name string) (e error) {
 }
 
 // Update updates a fake resource.Client
-func (c *SubresourceClient) Update(namespace string, templateValues interface{}) (e error) {
+func (c *SubresourceClient) Update(namespace string, name string, templateValues interface{}) (e error) {
 	if c.Error != "" {
 		e = fmt.Errorf(c.Error)
 	}

--- a/pkg/resource/fake/types.go
+++ b/pkg/resource/fake/types.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2018 Intel Corporation
+// Copyright (c) 2019 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/resource/fake/types.go
+++ b/pkg/resource/fake/types.go
@@ -73,7 +73,15 @@ func (c *SubresourceClient) Delete(namespace, name string) (e error) {
 }
 
 // Update updates a fake resource.Client
-func (c *SubresourceClient) Update(namespace string, name string, data []byte) (e error) {
+func (c *SubresourceClient) Update(namespace string, templateValues interface{}) (e error) {
+	if c.Error != "" {
+		e = fmt.Errorf(c.Error)
+	}
+	return
+}
+
+// Patch patches a fake resource.Client
+func (c *SubresourceClient) Patch(namespace string, name string, data []byte) (e error) {
 	if c.Error != "" {
 		e = fmt.Errorf(c.Error)
 	}

--- a/pkg/resource/godoc.md
+++ b/pkg/resource/godoc.md
@@ -16,6 +16,10 @@ type Client interface {
 	Create(namespace string, templateValues interface{}) error
 	// Delete deletes the object.
 	Delete(namespace string, name string) error
+	// Update updates the object.
+	Update(namespace string, templateValues interface{}) error
+	// Patch updates the object using JSON patch.
+	Patch(namespace string, name string, data []byte) error
 	// Get retrieves the object.
 	Get(namespace, name string) (runtime.Object, error)
 	// List lists objects based on group, version and kind.
@@ -74,6 +78,13 @@ NewPodClient returns a new pod client.
 func NewServiceClient(globalTemplateValues GlobalTemplateValues, clientSet *kubernetes.Clientset, templateFileName string) Client
 ```
 NewServiceClient returns a new service client.
+
+#### func  NewConfigMapClient
+
+```go
+func NewConfigMapClient(globalTemplateValues GlobalTemplateValues, clientSet *kubernetes.Clientset, templateFileName string) Client
+```
+NewConfigMapClient returns a new config map client.
 
 #### type GlobalTemplateValues
 

--- a/pkg/resource/hpa_client.go
+++ b/pkg/resource/hpa_client.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2018 Intel Corporation
+// Copyright (c) 2019 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/resource/hpa_client.go
+++ b/pkg/resource/hpa_client.go
@@ -96,7 +96,33 @@ func (c *hpaClient) Delete(namespace, name string) error {
 	return request.Do().Error()
 }
 
-func (c *hpaClient) Update(namespace string, name string, data []byte) error {
+func (c *hpaClient) Update(namespace string, name string, templateValues interface{}) error {
+	resourceBody, err := c.Reify(templateValues)
+	if err != nil {
+		return err
+	}
+
+	request := c.restClient.Put().
+		Namespace(namespace).
+		Resource(c.resourcePluralForm).
+		Name(name).
+		Body(resourceBody)
+
+	glog.Infof("[DEBUG] update resource URL: %s", request.URL())
+
+	var statusCode int
+	err = request.Do().StatusCode(&statusCode).Error()
+
+	if err != nil {
+		return err
+	}
+	if statusCode != http.StatusOK && statusCode != http.StatusCreated {
+		return fmt.Errorf("unexpected status code (%d)", statusCode)
+	}
+	return nil
+}
+
+func (c *hpaClient) Patch(namespace string, name string, data []byte) error {
 
 	request := c.restClient.Patch(types.JSONPatchType).
 		Resource(c.resourcePluralForm).
@@ -104,7 +130,7 @@ func (c *hpaClient) Update(namespace string, name string, data []byte) error {
 		Name(name).
 		Body(data)
 
-	glog.Infof("[DEBUG] update resource URL: %s", request.URL())
+	glog.Infof("[DEBUG] patch resource URL: %s", request.URL())
 
 	return request.Do().Error()
 }

--- a/pkg/resource/ingress_client.go
+++ b/pkg/resource/ingress_client.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2018 Intel Corporation
+// Copyright (c) 2019 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/resource/job_client.go
+++ b/pkg/resource/job_client.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2018 Intel Corporation
+// Copyright (c) 2019 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/resource/job_client.go
+++ b/pkg/resource/job_client.go
@@ -102,7 +102,33 @@ func (c *jobClient) Delete(namespace, name string) error {
 	return request.Do().Error()
 }
 
-func (c *jobClient) Update(namespace string, name string, data []byte) error {
+func (c *jobClient) Update(namespace string, name string, templateValues interface{}) error {
+	resourceBody, err := c.Reify(templateValues)
+	if err != nil {
+		return err
+	}
+
+	request := c.restClient.Put().
+		Namespace(namespace).
+		Resource(c.resourcePluralForm).
+		Name(name).
+		Body(resourceBody)
+
+	glog.Infof("[DEBUG] update resource URL: %s", request.URL())
+
+	var statusCode int
+	err = request.Do().StatusCode(&statusCode).Error()
+
+	if err != nil {
+		return err
+	}
+	if statusCode != http.StatusOK && statusCode != http.StatusCreated {
+		return fmt.Errorf("unexpected status code (%d)", statusCode)
+	}
+	return nil
+}
+
+func (c *jobClient) Patch(namespace string, name string, data []byte) error {
 
 	request := c.restClient.Patch(types.JSONPatchType).
 		Resource(c.resourcePluralForm).
@@ -110,7 +136,7 @@ func (c *jobClient) Update(namespace string, name string, data []byte) error {
 		Name(name).
 		Body(data)
 
-	glog.Infof("[DEBUG] update resource URL: %s", request.URL())
+	glog.Infof("[DEBUG] patch resource URL: %s", request.URL())
 
 	return request.Do().Error()
 }

--- a/pkg/resource/pod_client.go
+++ b/pkg/resource/pod_client.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2018 Intel Corporation
+// Copyright (c) 2019 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/resource/pod_client.go
+++ b/pkg/resource/pod_client.go
@@ -97,7 +97,33 @@ func (c *podClient) Delete(namespace, name string) error {
 	return request.Do().Error()
 }
 
-func (c *podClient) Update(namespace string, name string, data []byte) error {
+func (c *podClient) Update(namespace string, name string, templateValues interface{}) error {
+	resourceBody, err := c.Reify(templateValues)
+	if err != nil {
+		return err
+	}
+
+	request := c.restClient.Put().
+		Namespace(namespace).
+		Resource(c.resourcePluralForm).
+		Name(name).
+		Body(resourceBody)
+
+	glog.Infof("[DEBUG] update resource URL: %s", request.URL())
+
+	var statusCode int
+	err = request.Do().StatusCode(&statusCode).Error()
+
+	if err != nil {
+		return err
+	}
+	if statusCode != http.StatusOK && statusCode != http.StatusCreated {
+		return fmt.Errorf("unexpected status code (%d)", statusCode)
+	}
+	return nil
+}
+
+func (c *podClient) Patch(namespace string, name string, data []byte) error {
 
 	request := c.restClient.Patch(types.JSONPatchType).
 		Resource(c.resourcePluralForm).
@@ -105,7 +131,7 @@ func (c *podClient) Update(namespace string, name string, data []byte) error {
 		Name(name).
 		Body(data)
 
-	glog.Infof("[DEBUG] update resource URL: %s", request.URL())
+	glog.Infof("[DEBUG] patch resource URL: %s", request.URL())
 
 	return request.Do().Error()
 }

--- a/pkg/resource/service_client.go
+++ b/pkg/resource/service_client.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2018 Intel Corporation
+// Copyright (c) 2019 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/resource/service_client.go
+++ b/pkg/resource/service_client.go
@@ -96,7 +96,33 @@ func (c *serviceClient) Delete(namespace, name string) error {
 	return request.Do().Error()
 }
 
-func (c *serviceClient) Update(namespace string, name string, data []byte) error {
+func (c *serviceClient) Update(namespace string, name string, templateValues interface{}) error {
+	resourceBody, err := c.Reify(templateValues)
+	if err != nil {
+		return err
+	}
+
+	request := c.restClient.Put().
+		Namespace(namespace).
+		Resource(c.resourcePluralForm).
+		Name(name).
+		Body(resourceBody)
+
+	glog.Infof("[DEBUG] update resource URL: %s", request.URL())
+
+	var statusCode int
+	err = request.Do().StatusCode(&statusCode).Error()
+
+	if err != nil {
+		return err
+	}
+	if statusCode != http.StatusOK && statusCode != http.StatusCreated {
+		return fmt.Errorf("unexpected status code (%d)", statusCode)
+	}
+	return nil
+}
+
+func (c *serviceClient) Patch(namespace string, name string, data []byte) error {
 
 	request := c.restClient.Patch(types.JSONPatchType).
 		Resource(c.resourcePluralForm).
@@ -104,7 +130,7 @@ func (c *serviceClient) Update(namespace string, name string, data []byte) error
 		Name(name).
 		Body(data)
 
-	glog.Infof("[DEBUG] update resource URL: %s", request.URL())
+	glog.Infof("[DEBUG] patch resource URL: %s", request.URL())
 
 	return request.Do().Error()
 }


### PR DESCRIPTION
Summary of changes:
- Increase Golang version due https://github.com/golang/lint/issues/421
- Add configMap resource
- Change Update method, now it use HTTP PUT method instead of PATCH
- Add Patch method which is identical version of previous Update method
Two last changes have been implemented due to be consistent with k8s api

Testing done:
- I manually built all dockers, that normally were build by CI and all were ok. If someone want i can provide logs from that operations